### PR TITLE
fix loading issue

### DIFF
--- a/activesupport-cache-redis_multiplexer.gemspec
+++ b/activesupport-cache-redis_multiplexer.gemspec
@@ -1,7 +1,7 @@
 # coding: utf-8
 lib = File.expand_path('../lib', __FILE__)
 $LOAD_PATH.unshift(lib) unless $LOAD_PATH.include?(lib)
-require 'activesupport/cache/redis_multiplexer'
+require 'active_support/cache/redis_multiplexer'
 
 Gem::Specification.new do |spec|
   spec.name          = "activesupport-cache-redis_multiplexer"

--- a/bin/console
+++ b/bin/console
@@ -1,7 +1,7 @@
 #!/usr/bin/env ruby
 
 require "bundler/setup"
-require "activesupport/cache/redis_multiplexer"
+require "active_support/cache/redis_multiplexer"
 
 # You can add fixtures and/or initialization code here to make experimenting
 # with your gem easier. You can also use a different console, if you like.

--- a/lib/active_support/cache/redis_multiplexer.rb
+++ b/lib/active_support/cache/redis_multiplexer.rb
@@ -3,7 +3,7 @@ require 'forwardable'
 
 module ActiveSupport::Cache
   class RedisMultiplexer < Store
-    VERSION = "0.1.1"
+    VERSION = "0.1.2"
 
     extend Forwardable
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,2 +1,2 @@
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'activesupport/cache/redis_multiplexer'
+require 'active_support/cache/redis_multiplexer'


### PR DESCRIPTION
We are trying to use the gem, but ActiveSupport (5.0.0.1) cannot load the gem automatically. It is looking for a load path of `active_support/cache/redis_multiplexer`. This change updates the path to include the underscore and updates other references in the gem. 